### PR TITLE
mysql 容器使用的root用户名

### DIFF
--- a/docs/basic/install.md
+++ b/docs/basic/install.md
@@ -137,7 +137,7 @@ MySQL 端口 => `3306`
 
 MySQL 库名 => `tank` 
 
-MySQL 用户名 => `tank` 
+MySQL 用户名 => `root` 
 
 MySQL 密码 => `tank123` 
 :::


### PR DESCRIPTION
mysql 容器使用的root用户名，使用默认的`tank`用户名，数据库连接会通过不了